### PR TITLE
Add Python 3.5 testing to build matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]  # python 3.8 not supported by Github actions yet
+        python-version: [3.5, 3.6, 3.7]  # python 3.8 not supported by Github actions yet
         os: [ubuntu-latest]  # macos-latest has long queue times, broken on windows-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This commit tracks compatability of the codebase with Python 3.5. The remaining feature to migrate over seems to be the heavy use of Python 3.6's NamedTuple in `schedule.py`.

Fixes #88 