### PR TITLE
Fix tutorial to install checkmate using public repo URL

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install tensorflow>=2.0.0
         pip install -e .[test]
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -5,14 +5,8 @@
 
 # Installation
 ```bash
-$  git clone https://github.com/parasj/checkmate.git
-$  cd checkmate
-$  pip install -e .[eval,test]
-$  py.test
+pip install https://github.com/parasj/checkmate/archive/master.zip#egg=checkmate
 ```
-If you are evaluating on a GPU instance, run `pip install -e .[eval,gpu,test]` to install `tensorflow-gpu`.
-
-ZSH complains with the extras syntax on local directories so you may need to escape square brackets e.g. `pip install -e .\[eval,test\]`.
 
 # Citation
 If you use Checkmate in your work, please cite us with:

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,10 @@ setup(
         "matplotlib",  # this is only used once in the core checkmate package
         "numpy",
         "pandas",
-        "tensorflow>=2.0.0",
         "toposort",
         "psutil",
     ],
     extras_require={
-        "gpu": ["tensorflow-gpu>=2.0.0"],
         "eval": [
             "graphviz",
             "keras_segmentation @ https://github.com/ajayjain/image-segmentation-keras/archive/master.zip#egg=keras_segmentation-0.2.0remat",

--- a/tutorials/tutorial_basic_tf2_example.ipynb
+++ b/tutorials/tutorial_basic_tf2_example.ipynb
@@ -12,8 +12,8 @@
    },
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "!pip install tqdm tensorflow;"
+    "!pip install https://github.com/parasj/checkmate/archive/master.zip#egg=checkmate\n",
+    "!pip install tensorflow-gpu>=2.0.0 tqdm"
    ]
   },
   {
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "\n",
     "import checkmate\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
@@ -194,10 +193,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },


### PR DESCRIPTION
Now that the URL is public, I am updating the main checkmate package along with the tutorial.