### PR TITLE
Prototype timestep-limit range

### DIFF
--- a/checkmate/core/solvers/cvxpy_solver.py
+++ b/checkmate/core/solvers/cvxpy_solver.py
@@ -13,18 +13,18 @@ from checkmate.core.utils.timer import Timer
 
 
 class ILPSolverCVXPY:
-    def __init__(self, g: DFGraph, budget: int):
+    def __init__(self, g: DFGraph, budget: int, integral=False):
         self.budget = budget
         self.g = g
-        self.T = self.g.size
+        self.T = int(np.ceil(np.log2(self.g.size // 2)))
 
-        self.R = cp.Variable((self.T, self.T), name="R")
-        self.S = cp.Variable((self.T, self.T), name="S")
-        self.Free_E = cp.Variable((self.T, len(self.g.edge_list)), name="FREE_E")
-        self.U = cp.Variable((self.T, self.T), name="U")
+        self.R = cp.Variable((self.T, self.g.size), name="R", boolean=integral)
+        self.S = cp.Variable((self.T, self.g.size), name="S", boolean=integral)
+        self.Free_E = cp.Variable((self.T, len(self.g.edge_list)), name="FREE_E", boolean=integral)
+        self.U = cp.Variable((self.T, self.g.size), name="U")
 
-        cpu_cost_vec = np.asarray([self.g.cost_cpu[i] for i in range(self.T)])[np.newaxis, :].T
-        assert cpu_cost_vec.shape == (self.T, 1)
+        cpu_cost_vec = np.asarray([self.g.cost_cpu[i] for i in range(self.g.size)])[np.newaxis, :].T
+        assert cpu_cost_vec.shape == (self.g.size, 1)
         objective = cp.Minimize(cp.sum(self.R @ cpu_cost_vec))
         constraints = self.make_constraints(budget)
         self.problem = cp.Problem(objective, constraints)
@@ -33,19 +33,19 @@ class ILPSolverCVXPY:
 
     def make_constraints(self, budget):
         constraints = []
-        T = self.T
         ram_costs = self.g.cost_ram
-        ram_cost_vec = np.asarray([ram_costs[i] for i in range(T)])
+        ram_cost_vec = np.asarray([ram_costs[i] for i in range(self.g.size)])
 
         with Timer("Var bounds"):
             constraints.extend([self.R >= 0, self.R <= 1])
             constraints.extend([self.S >= 0, self.S <= 1])
             constraints.extend([self.Free_E >= 0, self.Free_E <= 1])
             constraints.extend([self.U >= 0, self.U <= budget])
-            constraints.append(cp.diag(self.R) == 1)
-            constraints.append(cp.diag(self.S) == 0)
-            constraints.append(cp.upper_tri(self.R) == 0)
-            constraints.append(cp.upper_tri(self.S) == 0)
+
+            constraints.append(self.R[0, self.g.vfwd] == 1)
+            constraints.append(self.S[0] == 0)
+            constraints.append(cp.sum(self.R[:, self.g.vfwd], axis=0) <= 2)
+            constraints.append(cp.sum(self.R[:, self.g.vbwd], axis=0) == 1)
 
         with Timer("Correctness constraints"):
             # ensure all checkpoints are in memory
@@ -57,7 +57,7 @@ class ILPSolverCVXPY:
 
         with Timer("Free_E constraints"):
             # Constraint: sum_k Free_{t,i,k} <= 1
-            for i in range(T):
+            for i in range(self.g.size):
                 frees = [self.Free_E[:, eidx] for eidx, (j, _) in enumerate(self.g.edge_list) if i == j]
                 if frees:
                     constraints.append(cp.sum(frees, axis=0) <= 1)
@@ -74,7 +74,7 @@ class ILPSolverCVXPY:
 
         with Timer("U constraints"):
             constraints.append(self.U[:, 0] == self.R[:, 0] * ram_costs[0] + ram_cost_vec @ self.S.T)
-            for k in range(T - 1):
+            for k in range(self.g.size - 1):
                 mem_freed = cp.sum([ram_costs[i] * self.Free_E[:, eidx] for (eidx, i) in self.g.predecessors_indexed(k)])
                 constraints.append(self.U[:, k + 1] == self.U[:, k] + self.R[:, k + 1] * ram_costs[k + 1] - mem_freed)
         return constraints
@@ -98,50 +98,51 @@ class ILPSolverCVXPY:
         return self.R.value, self.S.value, self.U.value, self.Free_E.value
 
 
-def solve_checkmate_cvxpy(
-    g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None, verbose=True
-):
-    lpsolver = ILPSolverCVXPY(g, int(0.9 * budget))  # rounding threshold
-    try:
-        r, s, u, free_e = lpsolver.solve(solver_override=solver_override, verbose=verbose)
-        lp_feasible = True
-    except ValueError as e:
-        logging.exception(e)
-        r, s, u, free_e = (None, None, None, None)
-        lp_feasible = False
-    schedule, aux_data, min_threshold = None, None, None
-    if lp_feasible:  # round the solution
-        for threshold in rounding_thresholds:
-            s_ = (s >= threshold).astype(np.int)
-            r_ = solve_r_opt(g, s_)
-            schedule_, aux_data_ = schedule_from_rs(g, r_, s_)
-            if aux_data_.activation_ram <= budget and (aux_data is None or aux_data_.cpu <= aux_data.cpu):
-                aux_data = aux_data_
-                schedule = schedule_
-                min_threshold = threshold
-    solve_strategy = (
-        SolveStrategy.APPROX_DET_ROUND_LP_05_THRESH
-        if len(rounding_thresholds) == 1
-        else SolveStrategy.APPROX_DET_ROUND_LP_SWEEP
-    )
-    return ScheduledResult(
-        solve_strategy=solve_strategy,
-        solver_budget=budget,
-        feasible=lp_feasible and aux_data is not None,
-        schedule=schedule,
-        schedule_aux_data=aux_data,
-        solve_time_s=lpsolver.solve_time,
-        ilp_aux_data=ILPAuxData(
-            U=u,
-            Free_E=free_e,
-            ilp_approx=False,
-            ilp_time_limit=None,
-            ilp_eps_noise=0.0,
-            ilp_num_constraints=lpsolver.num_vars,
-            ilp_num_variables=lpsolver.num_constraints,
-            approx_deterministic_round_threshold=min_threshold,
-        ),
-    )
+def solve_checkmate_cvxpy(g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None, verbose=False, integral=True):
+    lpsolver = ILPSolverCVXPY(g, budget, integral=integral)  # rounding threshold
+    r, s, u, free_e = lpsolver.solve(solver_override=solver_override, verbose=verbose)
+    return r, s, u, free_e
+
+    # try:
+    #     r, s, u, free_e = lpsolver.solve(solver_override=solver_override)
+    #     lp_feasible = True
+    # except ValueError as e:
+    #     logging.exception(e)
+    #     r, s, u, free_e = (None, None, None, None)
+    #     lp_feasible = False
+    # schedule, aux_data, min_threshold = None, None, None
+    # if lp_feasible:  # round the solution
+    #     for threshold in rounding_thresholds:
+    #         s_ = (s >= threshold).astype(np.int)
+    #         r_ = solve_r_opt(g, s_)
+    #         schedule_, aux_data_ = schedule_from_rs(g, r_, s_)
+    #         if aux_data_.activation_ram <= budget and (aux_data is None or aux_data_.cpu <= aux_data.cpu):
+    #             aux_data = aux_data_
+    #             schedule = schedule_
+    #             min_threshold = threshold
+    # solve_strategy = (
+    #     SolveStrategy.APPROX_DET_ROUND_LP_05_THRESH
+    #     if len(rounding_thresholds) == 1
+    #     else SolveStrategy.APPROX_DET_ROUND_LP_SWEEP
+    # )
+    # return ScheduledResult(
+    #     solve_strategy=solve_strategy,
+    #     solver_budget=budget,
+    #     feasible=lp_feasible and aux_data is not None,
+    #     schedule=schedule,
+    #     schedule_aux_data=aux_data,
+    #     solve_time_s=lpsolver.solve_time,
+    #     ilp_aux_data=ILPAuxData(
+    #         U=u,
+    #         Free_E=free_e,
+    #         ilp_approx=False,
+    #         ilp_time_limit=None,
+    #         ilp_eps_noise=0.0,
+    #         ilp_num_constraints=lpsolver.num_vars,
+    #         ilp_num_variables=lpsolver.num_constraints,
+    #         approx_deterministic_round_threshold=min_threshold,
+    #     ),
+    # )
 
 
 # Extra, unnecessary constraints

--- a/scripts/compressed_time.ipynb
+++ b/scripts/compressed_time.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from checkmate.plot.definitions import checkmate_data_dir\n",
+    "from checkmate.core.graph_builder import gen_linear_graph\n",
+    "from checkmate.core.solvers.cvxpy_solver import solve_checkmate_cvxpy\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "import numpy as np\n",
+    "from tqdm import tqdm\n",
+    "import logging\n",
+    "import pandas as pd\n",
+    "sns.set('notebook')\n",
+    "sns.set_style('dark')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_solution(r, s, u):\n",
+    "    fix, axs = plt.subplots(3, figsize=(20, 6))\n",
+    "    \n",
+    "    axs[0].invert_yaxis()\n",
+    "    axs[0].pcolormesh(r, cmap=\"Greys\", vmin=0, vmax=1.0, edgecolors='white')\n",
+    "    axs[0].set_title(\"R\")\n",
+    "\n",
+    "    axs[1].invert_yaxis()\n",
+    "    axs[1].pcolormesh(s, cmap=\"Greys\", vmin=0, vmax=1.0, edgecolors='white')\n",
+    "    axs[1].set_title(\"S\")\n",
+    "\n",
+    "    axs[2].invert_yaxis()\n",
+    "    axs[2].pcolormesh(u, cmap=\"Greys\", vmin=0, vmax=np.max(u))\n",
+    "    axs[2].set_title(\"U\")\n",
+    "\n",
+    "logdir = checkmate_data_dir() / \"compressed_time\"\n",
+    "logdir.mkdir(parents=True, exist_ok=True)\n",
+    "k = 64\n",
+    "g = gen_linear_graph(k)\n",
+    "budget = 16\n",
+    "r, s, u, free_e = solve_checkmate_cvxpy(g, budget, verbose=True, integral=True)\n",
+    "plot_solution(r, s, u)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This pull request adds the ability to limit the number of timesteps that the solver will attempt to unroll solutions over. In the paper, we set `T = | V |` so there were `O(| V |^2)` variables where `| V |` denotes the size of the graph.

However, open source solvers have significantly lower throughputs as compared to Gurobi, a commercial ILP solver used in evaluation. This PR proposes limiting the total number of timesteps which a schedule is solved over. This will limit the number of times a node can be rematerialized, but will make schedules feasible to solve quickly.

@hy00nc 