### PR TITLE
Fix incorrect budget calculation, add CyLP dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,32 @@ At the moment, Checkmate only supports TensorFlow 2.0. PyTorch support is coming
 
 ## Installation
 
-Get started with `pip install "https://github.com/parasj/checkmate/archive/master.zip#egg=checkmate"`
+Checkmate depends on:
+* [TensorFlow 2.0](https://www.tensorflow.org/install), i.e. `pip install tensorflow` or `pip install tensorflow-gpu`.
+* [CyLP solver](https://github.com/coin-or/CyLP)
+    <details><summary>Installing CyLP on Debian Linux / Ubuntu</summary>
+    <p>
 
-Ensure you have installed either `tensorflow-gpu>=2.0.0` or `tensorflow`.
+    ```bash
+    $ sudo apt install coinor-cbc coinor-libcbc-dev
+    $ pip install cylp
+    ```
+    </p>
+    </details>
+    <details><summary>Installing CyLP on MacOS</summary>
+    <p>
+    
+    The easiest way to set up CyLP is using [homebrew](https://brew.sh/).
+    ```bash
+    $ brew tap coin-or-tools/coinor
+    $ brew install coin-or-tools/coinor/cbc pkg-config
+    $ pip install cylp
+    ```
+    </p>
+    </details>
+
+
+Once TensorFlow 2.0 and CyLP are installed, Checkmate can be installed using pip via `pip install "https://github.com/parasj/checkmate/archive/master.zip#egg=checkmate"`.
 
 ## Quick start
 
@@ -33,7 +56,6 @@ for image, label in train_ds:
 ## Key ideas
 
 From our [paper at MLSys 2020](https://arxiv.org/abs/1910.02653):
-
 ```text
 Modern neural networks are increasingly bottlenecked by the limited capacity of on-device
 GPU memory. Prior work explores dropping activations as a strategy to scale to larger
@@ -62,4 +84,3 @@ If you use Checkmate in your work, please cite us with:
   year={2020}
 }
 ```
-

--- a/checkmate/core/solvers/cvxpy_solver.py
+++ b/checkmate/core/solvers/cvxpy_solver.py
@@ -98,10 +98,10 @@ class ILPSolverCVXPY:
         return self.R.value, self.S.value, self.U.value, self.Free_E.value
 
 
-def solve_checkmate_cvxpy(g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None):
+def solve_checkmate_cvxpy(g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None, verbose=True):
     lpsolver = ILPSolverCVXPY(g, int(0.9 * budget))  # rounding threshold
     try:
-        r, s, u, free_e = lpsolver.solve(solver_override=solver_override)
+        r, s, u, free_e = lpsolver.solve(solver_override=solver_override, verbose=verbose)
         lp_feasible = True
     except ValueError as e:
         logging.exception(e)

--- a/checkmate/core/solvers/cvxpy_solver.py
+++ b/checkmate/core/solvers/cvxpy_solver.py
@@ -98,7 +98,9 @@ class ILPSolverCVXPY:
         return self.R.value, self.S.value, self.U.value, self.Free_E.value
 
 
-def solve_checkmate_cvxpy(g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None, verbose=True):
+def solve_checkmate_cvxpy(
+    g, budget, rounding_thresholds=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), solver_override=None, verbose=True
+):
     lpsolver = ILPSolverCVXPY(g, int(0.9 * budget))  # rounding threshold
     try:
         r, s, u, free_e = lpsolver.solve(solver_override=solver_override, verbose=verbose)

--- a/checkmate/tf2/wrapper.py
+++ b/checkmate/tf2/wrapper.py
@@ -33,7 +33,7 @@ def nvidiasmi_query(query="memory.total"):
     return dict(zip(range(len(query_result_list)), query_result_list))
 
 
-def _get_gpu_memory():
+def _get_gpu_memory_bytes():
     if _using_gpu_check():  # choose based on available GPU RAM
         gpu_ram = nvidiasmi_query("memory.total")
         budget = min(gpu_ram.values()) * 0.9
@@ -45,7 +45,7 @@ def _get_gpu_memory():
         budget = psutil.virtual_memory().available * 0.8 / 1000000
         logging.debug("[checkmate] No GPU detected, using system DRAM on CPU")
         logging.info("[checkmate] No budget specified; defaulting to {0:.2f}MB".format(budget))
-    return budget
+    return budget * 1000000
 
 
 def get_function(model, input_shape, label_shape, optimizer, loss):
@@ -93,7 +93,7 @@ def compile_tf2(
 
     # query budget if not specified
     if budget == "auto":
-        budget = _get_gpu_memory()
+        budget = _get_gpu_memory_bytes()
 
     # build gradient function for model
     @tf.function

--- a/checkmate/tf2/wrapper.py
+++ b/checkmate/tf2/wrapper.py
@@ -61,14 +61,7 @@ def get_function(model, input_shape, label_shape, optimizer, loss):
 
 
 def compile_tf2(
-    model: tf.keras.Model,
-    loss,
-    optimizer,
-    input_spec=None,
-    label_spec=None,
-    scheduler=solver,
-    budget="auto",
-    **kwargs
+    model: tf.keras.Model, loss, optimizer, input_spec=None, label_spec=None, scheduler=solver, budget="auto", **kwargs
 ):
     set_opts()
     """
@@ -110,7 +103,9 @@ def compile_tf2(
     # choose solver and calculate solver
     sched_result = scheduler(g, budget, **kwargs)
     if not sched_result.feasible:
-        logging.error("[checkmate] Checkmate solver could find no feasible schedule for the specificed budget of {}".format(budget))
+        logging.error(
+            "[checkmate] Checkmate solver could find no feasible schedule for the specificed budget of {}".format(budget)
+        )
         raise ValueError("No feasible solution for specified budget of {}".format(budget))
     logging.debug("[checkmate] Schedule solved")
 

--- a/tutorials/tutorial_basic_tf2_example.ipynb
+++ b/tutorials/tutorial_basic_tf2_example.ipynb
@@ -12,8 +12,10 @@
    },
    "outputs": [],
    "source": [
+    "!sudo apt install coinor-cbc coinor-libcbc-dev\n",
+    "!pip install cylp tensorflow-gpu>=2.0.0 tqdm\n",
+    "\n",
     "import os\n",
-    "!pip install tensorflow-gpu>=2.0.0 tqdm\n",
     "try:\n",
     "    from checkmate.tf2 import get_keras_model\n",
     "except:\n",


### PR DESCRIPTION
Fixes #144 

This PR fixes two bugs in the tutorial workflow:
1. CVXPY defaults to using ECOS as a solver which appears to return infeasible schedules at lower memory budgets.
2. `_get_gpu_memory` returned total system memory capacity in MB rather than bytes. https://github.com/parasj/checkmate/blob/28fc0b6bcc346b082bc81ef4881f7736a32f1af0/checkmate/tf2/wrapper.py#L36-L48

I added documentation about installing CBC as an alternative solver in the README and corrected the byte count issue.